### PR TITLE
Fix `bipartite-color` for digraphs with nodes with no outgoing edges

### DIFF
--- a/src/loom/alg.cljc
+++ b/src/loom/alg.cljc
@@ -435,7 +435,7 @@ can use these functions."
                 coloring
                 (let [v (peek queue)
                       color (- 1 (coloring v))
-                      nbrs (graph/successors g v)]
+                      nbrs (graph/neighbors g v)]
                   ;; TODO: could be better
                   (if (some #(and (coloring %) (= (coloring v) (coloring %)))
                             nbrs)

--- a/src/loom/graph.cljc
+++ b/src/loom/graph.cljc
@@ -5,6 +5,7 @@ on adjacency lists."
       :author "Justin Kramer"}
   loom.graph
   (:require [loom.alg-generic :refer [bf-traverse]]
+            [clojure.set :as clj.set]
             #?@(:clj [[loom.cljs :refer (def-protocol-impls)]]))
   #?@(:cljs [(:require-macros [loom.cljs :refer [def-protocol-impls extend]])]))
 
@@ -78,6 +79,14 @@ on adjacency lists."
   "Returns direct predecessors of node"
   ([g] #(predecessors g %))
   ([g node] (predecessors* g node)))
+
+(defn neighbors
+  "Returns all neighbors of node"
+  ([g] #(neighbors g %))
+  ([g node]
+   (clj.set/union
+    (set (predecessors g node))
+    (set (successors g node)))))
 
 (defn weight
  "Returns the weight of edge e or edge [n1 n2]"


### PR DESCRIPTION
An issue came up over in the [Ubergraph](https://github.com/Engelberg/ubergraph/issues/35) repository about a failure with `bipartite-color` in the case of digraphs. There is discussion about the problem and solution there. It turns out this function comes from Loom, so I am submitting the fix here. 

As it seems the code was expecting `successors` to perform as a general `neighbors` function I wonder if this assumption is being made anywhere else in the code? I know this PR adds `neighbors` to the core API but IMO this function is fundamental enough to justify it. 

Open to all thoughts and feedback, thanks!