### PR TITLE
Add a rudimentary deps.edn file

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps  {org.clojure/data.priority-map   {:mvn/version "0.0.10"}
+         tailrecursion/cljs-priority-map {:mvn/version "1.2.1"}}}


### PR DESCRIPTION
This PR just adds a `deps.edn` file with the necessary dependencies specified in order to allow one to depend on Loom via git deps. Relevant issue is here https://github.com/aysylu/loom/issues/135

I tested it in my project by including the following coordinates in my project's deps file:

```
aysylu/loom {:git/url "https://github.com/cjsauer/loom.git"
             :sha     "acd15ed3136a0f4091e97bfc187764ff8b60da4e"}
```

This worked fine in both CLJ and CLJS (my project is CLJC).